### PR TITLE
Auth helper: submit is input not button, accept custom password

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,12 @@ npm run test
 
 ## Environment Variables
 
-| Variable              | Default Value         | Description                              |
-| --------------------- | --------------------- | ---------------------------------------- |
-| TRUSTIFY_URL          | http://localhost:8080 | The UI URL                               |
-| TRUSTIFY_AUTH_ENABLED | false                 | Whether or not auth is enabled in the UI |
+| Variable               | Default Value         | Description                              |
+| ---------------------- | --------------------- | ---------------------------------------- |
+| TRUSTIFY_URL           | http://localhost:8080 | The UI URL                               |
+| TRUSTIFY_AUTH_ENABLED  | false                 | Whether or not auth is enabled in the UI |
+| TRUSTIFY_AUTH_USER     | admin                 | User name to be used when authenticating |
+| TRUSTIFY_AUTH_PASSWORD | admin                 | Password to be used when authenticating  |
 
 ## Available commands
 

--- a/tests/dependencies/global.setup.ts
+++ b/tests/dependencies/global.setup.ts
@@ -1,8 +1,11 @@
 import path from "path";
 import { expect, Page, test } from "@playwright/test";
+import { login } from "../helpers/Auth";
 
 test.describe("Ingest initial data", () => {
   test("SBOMs", async ({ page, baseURL }) => {
+    await login(page);
+
     await page.goto(baseURL!);
     await page.getByRole("link", { name: "Upload" }).click();
 

--- a/tests/helpers/Auth.ts
+++ b/tests/helpers/Auth.ts
@@ -1,0 +1,18 @@
+import { Page } from "@playwright/test";
+
+export const login = async (page: Page) => {
+  let shouldLogin = process.env.TRUSTIFY_AUTH_ENABLED;
+
+  if (shouldLogin === "true") {
+    let userName = process.env.TRUSTIFY_AUTH_USER ?? "admin";
+    let userPassword = process.env.TRUSTIFY_AUTH_PASSWORD ?? "admin";
+
+    await page.goto("/");
+
+    await page.fill('input[name="username"]:visible', userName);
+    await page.fill('input[name="password"]:visible', userPassword);
+    await page.click('input[type="submit"]:visible');
+
+    await page.waitForSelector("text=Your Dashboard"); // Ensure login was successful
+  }
+};

--- a/tests/helpers/Auth.ts
+++ b/tests/helpers/Auth.ts
@@ -11,7 +11,7 @@ export const login = async (page: Page) => {
 
     await page.fill('input[name="username"]:visible', userName);
     await page.fill('input[name="password"]:visible', userPassword);
-    await page.click('input[type="submit"]:visible');
+    await page.keyboard.press("Enter");
 
     await page.waitForSelector("text=Your Dashboard"); // Ensure login was successful
   }

--- a/tests/steps/auth.ts
+++ b/tests/steps/auth.ts
@@ -1,16 +1,8 @@
 import { createBdd } from "playwright-bdd";
+import { login } from "../helpers/Auth";
 
 export const { Given, When, Then } = createBdd();
 
 Given("User is authenticated", async ({ page }) => {
-  await page.goto("/");
-
-  let isLoggedIn = process.env.TRUSTIFY_AUTH_ENABLED;
-
-  if (isLoggedIn === "true") {
-    await page.fill('input[name="username"]', "admin");
-    await page.fill('input[name="password"]', "admin");
-    await page.click('button[type="submit"]');
-    await page.waitForSelector("text=Your Dashboard"); // Ensure login was successful
-  }
+  await login(page);
 });


### PR DESCRIPTION
Extract Auth/login to separate helper function,
so that it can be reused in both global setup for importing data as also by 'auth' step in test.

While doing so:
- fix the bug with attempting to click on `button[type=submit]` as it should be `input[type=submit]` instead
- accept env variables `TRUSTIFY_AUTH_USER` and `TRUSTIFY_AUTH_PASSWORD` allowing usage of custom credentials (keep defaults as admin:admin)
- scope locator searching for username/password and submit inputs to
  visible elements, as Cognito has in the page two forms for some reason
  where only one of them is visible (maybe this will need better
  detection if it is dynamically switched as then it could be flaky)