### PR TITLE
global-setup: extend ingestion timeout to 240s

### DIFF
--- a/tests/api/dependencies/global.setup.ts
+++ b/tests/api/dependencies/global.setup.ts
@@ -3,7 +3,11 @@ import path from "path";
 
 import { AxiosInstance } from "axios";
 
-import { ADVISORY_FILES, SBOM_FILES } from "../../common/constants";
+import {
+  ADVISORY_FILES,
+  SBOM_FILES,
+  SETUP_TIMEOUT,
+} from "../../common/constants";
 import { UploadSbomResponse } from "../client";
 import { test as setup } from "../fixtures";
 
@@ -14,7 +18,7 @@ setup.describe("Ingest initial data", () => {
   );
 
   setup("Upload files", async ({ axios }) => {
-    setup.setTimeout(120_000);
+    setup.setTimeout(SETUP_TIMEOUT);
     await uploadSboms(axios, SBOM_FILES);
     await uploadAdvisories(axios, ADVISORY_FILES);
   });

--- a/tests/common/constants.ts
+++ b/tests/common/constants.ts
@@ -17,6 +17,8 @@ export const logger = {
   },
 };
 
+export const SETUP_TIMEOUT = 240_000;
+
 export const SBOM_FILES = [
   "quarkus-bom-2.13.8.Final-redhat-00004.json.bz2",
   "ubi8_ubi-micro-8.8-7.1696517612.json.bz2",

--- a/tests/ui/dependencies/global.setup.ts
+++ b/tests/ui/dependencies/global.setup.ts
@@ -1,7 +1,11 @@
 import path from "path";
 import { expect, Page, test as setup } from "@playwright/test";
 import { login } from "../helpers/Auth";
-import { ADVISORY_FILES, SBOM_FILES } from "../../common/constants";
+import {
+  ADVISORY_FILES,
+  SBOM_FILES,
+  SETUP_TIMEOUT,
+} from "../../common/constants";
 
 setup.describe("Ingest initial data", () => {
   setup.skip(
@@ -15,7 +19,7 @@ setup.describe("Ingest initial data", () => {
     await page.goto(baseURL!);
     await page.getByRole("link", { name: "Upload" }).click();
 
-    setup.setTimeout(120_000);
+    setup.setTimeout(SETUP_TIMEOUT);
     await uploadSboms(page, SBOM_FILES);
     await uploadAdvisories(page, ADVISORY_FILES);
   });
@@ -34,7 +38,7 @@ const uploadSboms = async (page: Page, files: string[]) => {
   await expect(
     page.locator("#upload-sbom-tab-content .pf-v6-c-expandable-section__toggle")
   ).toContainText(`${files.length} of ${files.length} files uploaded`, {
-    timeout: 60_000,
+    timeout: SETUP_TIMEOUT / 2,
   });
 };
 
@@ -53,6 +57,6 @@ const uploadAdvisories = async (page: Page, files: string[]) => {
       "#upload-advisory-tab-content .pf-v6-c-expandable-section__toggle"
     )
   ).toContainText(`${files.length} of ${files.length} files uploaded`, {
-    timeout: 60_000,
+    timeout: SETUP_TIMEOUT / 2,
   });
 };


### PR DESCRIPTION
During initial setup of data ingestion of SBOMs
can take lot longer then current 60s timeout allows, in my attempted case with aws env the setup-data
timeout after 60s with only 3 from 6 files uploaded after that time.

Timeout should be only safety measure here
(its not a perf test, only one time pre-test setup) so bump to double of time which would suffice in my case.