### PR TITLE
WorkInProgress - Enable addition of API tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,15 @@ npm run test
 
 ## Environment Variables
 
-| Variable               | Default Value         | Description                                 |
-| ---------------------- | --------------------- | ------------------------------------------- |
-| TRUSTIFY_URL           | http://localhost:8080 | The UI URL                                  |
-| TRUSTIFY_AUTH_ENABLED  | false                 | Whether or not auth is enabled in the UI    |
-| TRUSTIFY_AUTH_USER     | admin                 | User name to be used when authenticating    |
-| TRUSTIFY_AUTH_PASSWORD | admin                 | Password to be used when authenticating     |
-| SKIP_INGESTION         | false                 | If to skip initial data ingestion / cleanup |
+| Variable                 | Default Value         | Description                                 |
+| ------------------------ | --------------------- | ------------------------------------------- |
+| TRUSTIFY_URL             | http://localhost:8080 | The UI URL                                  |
+| TRUSTIFY_AUTH_ENABLED    | false                 | Whether or not auth is enabled in the UI    |
+| TRUSTIFY_AUTH_USER       | admin                 | User name to be used when authenticating    |
+| TRUSTIFY_AUTH_PASSWORD   | admin                 | Password to be used when authenticating     |
+| TRUSTIFY_AUTH_CLI_ID     | cli                   | oidc cli client ID (for API tests)          |
+| TRUSTIFY_AUTH_CLI_SECRET |                       | oidc cli client secret (for API tests)      |
+| SKIP_INGESTION           | false                 | If to skip initial data ingestion / cleanup |
 
 ## Available commands
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -72,6 +72,16 @@ export default defineConfig({
     },
 
     {
+      name: "api",
+      testDir: "./tests/api",
+      testMatch: /.*\.ts/,
+      use: {
+        baseURL: process.env.TRUSTIFY_URL + "/api",
+      },
+      dependencies: ["setup-data"],
+    },
+
+    {
       name: "setup-data",
       testDir: "./tests/dependencies",
       testMatch: /global\.setup\.ts/,

--- a/tests/api/sbom-and-purl.ts
+++ b/tests/api/sbom-and-purl.ts
@@ -3,23 +3,10 @@
 import { expect } from "@playwright/test";
 import { api_test as test } from "../helpers/API";
 
-// FIXME: drop Auth helper here after moving beforeAll token initialization
-import { get_token, get_token_header } from "../helpers/Auth";
-// ---------
 
 // currently our global setup uploads just 6 sboms - so we cannot assert 10+
 const MIN_SBOMS_PRESENT = 6;
 
-// FIXME: possibly better to have this invoked just once at start from global-setup
-test.beforeAll(async ({ playwright }) => {
-  console.log("hello"); // FIXME: DEBUG
-
-  let request = await playwright.request.newContext();
-  let token = await get_token(request);
-  request.dispose();
-
-  console.log(`token before test: ${token.slice(0, 5)}...${token.slice(-5)}`); // FIXME: DEBUG
-});
 
 test("list first 10 sboms by name", async ({ request }) => {
   const sbomResp = await request.get(
@@ -40,6 +27,7 @@ test("list first 10 sboms by name", async ({ request }) => {
     );
   });
 });
+
 
 test("purl by alias", async ({ request }) => {
   const resp = await request.get("/api/v2/purl?q=openssl");

--- a/tests/api/sbom-and-purl.ts
+++ b/tests/api/sbom-and-purl.ts
@@ -1,0 +1,108 @@
+/* Example of testing API with SBOM and PURL endpoints */
+
+import { test, expect } from "@playwright/test";
+import { get_token, get_token_header } from "../helpers/Auth";
+
+// currently our global setup uploads just 6 sboms - so we cannot assert 10+
+const MIN_SBOMS_PRESENT = 6;
+
+// FIXME: possibly better to have this invoked just once at start from global-setup
+test.beforeAll(async ({ playwright }) => {
+  console.log("hello"); // FIXME: DEBUG
+
+  let request = await playwright.request.newContext();
+  let token = await get_token(request);
+  request.dispose();
+
+  console.log("token before test: " + token); // FIXME: DEBUG
+});
+
+test("oidc", async ({ request }) => {
+  let token = await get_token(request);
+  console.log("token in test: " + token);
+});
+
+test("list first 10 sboms by name", async ({ request }) => {
+  // FIXME: easiest way for obtaining token here?
+  //        - seems proper way may be using extra Fixture e.g. https://stackoverflow.com/a/72294948 ?
+  //        - or bit worse but also working to have test.beforeEach to set-refresh token?
+  //          but for that we still would need explicitely mention/refer to it with each request call?
+  //        - for this first example going with explicit call from inside test
+  const sbomResp = await request.get(
+    "/api/v2/sbom?limit=10&offset=0&sort=name:asc",
+    {
+      headers: await get_token_header(request),
+    }
+  );
+  expect(sbomResp).toBeOK();
+  const sbomJson = await sbomResp.json();
+  expect(sbomJson).toHaveProperty("items");
+  expect(sbomJson["items"].length).toBeGreaterThanOrEqual(MIN_SBOMS_PRESENT);
+  sbomJson["items"].forEach((sbom) => {
+    expect(sbom).toHaveProperty("name");
+    expect(sbom).toHaveProperty("number_of_packages");
+    expect(sbom).toHaveProperty("ingested");
+    // FIXME: DEBUG
+    console.log(
+      `SBOM ${sbom["name"]} with ${sbom["number_of_packages"]} at ${sbom["ingested"]}`
+    );
+  });
+});
+
+test("purl by alias", async ({ request }) => {
+  // FIXME: what is easiest way for obtaining token here?
+  const resp = await request.get("/api/v2/purl?q=openssl", {
+    headers: await get_token_header(request),
+  });
+  expect(resp).toBeOK();
+  const purls = await resp.json();
+  expect(purls).toHaveProperty("items");
+  // now here assert either structure (no idea if these are valid asserts, just demo)
+  purls.items.forEach((purl) => {
+    expect(purl).toHaveProperty("uuid");
+    expect(purl).toHaveProperty("purl");
+    expect(purl).toHaveProperty("base");
+    expect(purl).toHaveProperty("version");
+    expect(purl).toHaveProperty("qualifiers");
+  });
+  // or some exact data/entries
+  expect(purls.items).toEqual(
+    expect.arrayContaining([
+      {
+        uuid: "0ba8c525-a930-5e55-b8bb-3a666e5048b7",
+        purl: "pkg:rpm/redhat/openssl-libs@3.0.7-24.el9?arch=aarch64",
+        base: {
+          uuid: "69997203-ffc5-51e5-bae9-1881bb9fa8d7",
+          purl: "pkg:rpm/redhat/openssl-libs",
+        },
+        version: {
+          uuid: "b23d2c3f-a54a-5e81-8665-2013d4cc4d17",
+          purl: "pkg:rpm/redhat/openssl-libs@3.0.7-24.el9",
+          version: "3.0.7-24.el9",
+        },
+        qualifiers: { arch: "aarch64" },
+      },
+      {
+        uuid: "11ea8077-d87b-53ef-b8a7-8c64267cb290",
+        purl: "pkg:rpm/redhat/openssl-libs@3.0.7-24.el9?arch=x86_64",
+        base: {
+          uuid: "69997203-ffc5-51e5-bae9-1881bb9fa8d7",
+          purl: "pkg:rpm/redhat/openssl-libs",
+        },
+        version: {
+          uuid: "b23d2c3f-a54a-5e81-8665-2013d4cc4d17",
+          purl: "pkg:rpm/redhat/openssl-libs@3.0.7-24.el9",
+          version: "3.0.7-24.el9",
+        },
+        qualifiers: { arch: "x86_64" },
+      },
+    ])
+  );
+
+  //  expect(sbom).toHaveProperty('ingested');
+  //  // FIXME: DEBUG
+  //  console.log(`SBOM ${sbom['name']} with ${sbom['number_of_packages']} at ${sbom['ingested']}`);
+  //});
+  // FIXME: DEBUG
+  console.log(purls.items);
+});

--- a/tests/api/sbom-and-purl.ts
+++ b/tests/api/sbom-and-purl.ts
@@ -3,10 +3,8 @@
 import { expect } from "@playwright/test";
 import { api_test as test } from "../helpers/API";
 
-
 // currently our global setup uploads just 6 sboms - so we cannot assert 10+
 const MIN_SBOMS_PRESENT = 6;
-
 
 test("list first 10 sboms by name", async ({ request }) => {
   const sbomResp = await request.get(
@@ -27,7 +25,6 @@ test("list first 10 sboms by name", async ({ request }) => {
     );
   });
 });
-
 
 test("purl by alias", async ({ request }) => {
   const resp = await request.get("/api/v2/purl?q=openssl");

--- a/tests/dependencies/global.setup.ts
+++ b/tests/dependencies/global.setup.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import { expect, Page, test as setup } from "@playwright/test";
-import { login } from "../helpers/Auth";
+import { login, get_token } from "../helpers/Auth";
 
 setup.describe("Ingest initial data", () => {
   setup.skip(
@@ -58,6 +58,17 @@ setup.describe("Ingest initial data", () => {
     setup.setTimeout(120_000);
     await uploadSboms(page, sbom_files);
     await uploadAdvisories(page, advisory_files);
+  });
+});
+
+setup.describe("Initialize API token", () => {
+  setup.skip(process.env.TRUSTIFY_AUTH_ENABLED !== "true", "Skip token when auth is disabled");
+
+  setup("API token", async ({ request }) => {
+    // this is done in setup
+    // to discover and precache token endpoints for rest of the tests
+    let token = await get_token(request);
+    console.log(`api token: ${token.slice(0, 5)}...${token.slice(-5)}`);
   });
 });
 

--- a/tests/dependencies/global.setup.ts
+++ b/tests/dependencies/global.setup.ts
@@ -1,14 +1,14 @@
 import path from "path";
-import { expect, Page, test } from "@playwright/test";
+import { expect, Page, test as setup } from "@playwright/test";
 import { login } from "../helpers/Auth";
 
-test.describe("Ingest initial data", () => {
-  test.skip(
+setup.describe("Ingest initial data", () => {
+  setup.skip(
     process.env.SKIP_INGESTION === "true",
     "Skipping global.setup data ingestion"
   );
 
-  test("SBOMs", async ({ page, baseURL }) => {
+  setup("SBOMs", async ({ page, baseURL }) => {
     await login(page);
 
     await page.goto(baseURL!);
@@ -55,7 +55,7 @@ test.describe("Ingest initial data", () => {
       "cve-2023-28867.json.bz2",
     ];
 
-    test.setTimeout(120_000);
+    setup.setTimeout(120_000);
     await uploadSboms(page, sbom_files);
     await uploadAdvisories(page, advisory_files);
   });

--- a/tests/dependencies/global.setup.ts
+++ b/tests/dependencies/global.setup.ts
@@ -62,7 +62,10 @@ setup.describe("Ingest initial data", () => {
 });
 
 setup.describe("Initialize API token", () => {
-  setup.skip(process.env.TRUSTIFY_AUTH_ENABLED !== "true", "Skip token when auth is disabled");
+  setup.skip(
+    process.env.TRUSTIFY_AUTH_ENABLED !== "true",
+    "Skip token when auth is disabled"
+  );
 
   setup("API token", async ({ request }) => {
     // this is done in setup

--- a/tests/helpers/API.ts
+++ b/tests/helpers/API.ts
@@ -1,0 +1,67 @@
+import { test as test_base } from "@playwright/test";
+import { get_token_header } from "./Auth";
+
+export const api_test = test_base.extend({
+  request: async ({ request }, use) => {
+    /**
+     * APIRequestContext which automatically adds auth headers
+     *
+     * @example Allow sending request without caring about auth
+     * ```ts
+     * request.get('/url/some')
+     * request.post('/url/else', { data: "payload" })
+     * request.put('/url/extra', { data: "payload", headers: { Custom: 'x'} })
+     * ```
+     * Acts as APIReqestContext {@link https://playwright.dev/docs/api/class-apirequestcontext}
+     * (it wraps the original request context),
+     * while it also obtains token from Auth helper, and if provided (auth is enabled),
+     * ensures it is added to the issued request headers.
+     */
+
+    const MAGIC = async (options) => {
+      // FIXME: rename and see if can be placed outside this object
+      const token_headers = await get_token_header(request);
+      if (Object.keys(token_headers).length == 0) {
+        return options;
+      }
+      if (!options) {
+        return { headers: token_headers };
+      }
+      if (!options.headers) {
+        return { ...options, headers: token_headers };
+      }
+      return { ...options, headers: { ...options.headers, ...token_headers } };
+    };
+
+    const req = {
+      delete: async (url, options = null) => {
+        return request.delete(url, await MAGIC(options));
+      },
+      dispose: async (url, options = null) => {
+        return request.dispose(url, await MAGIC(options));
+      },
+      fetch: async (url, options = null) => {
+        return request.fetch(url, await MAGIC(options));
+      },
+      get: async (url, options = null) => {
+        return request.get(url, await MAGIC(options));
+      },
+      head: async (url, options = null) => {
+        return request.head(url, await MAGIC(options));
+      },
+      patch: async (url, options = null) => {
+        return request.patch(url, await MAGIC(options));
+      },
+      post: async (url, options = null) => {
+        return request.post(url, await MAGIC(options));
+      },
+      put: async (url, options = null) => {
+        return request.put(url, await MAGIC(options));
+      },
+      // not related to http requests, so just pass forward
+      storageState: request.storageState.bind(request),
+    };
+
+    use(req);
+  },
+});

--- a/tests/helpers/Auth.ts
+++ b/tests/helpers/Auth.ts
@@ -91,7 +91,7 @@ export const get_token = async (request: APIRequestContext) => {
   process.env.__TOKEN = token;
   process.env.__TOKEN_EXPIRES_AS = expires_at;
 
-  console.log("got fresh token: " + token); // FIXME: DEBUG
+  console.log(`got fresh token: ${token.slice(0, 5)}...${token.slice(-5)}`); // FIXME: DEBUG
 
   return token;
 };

--- a/tests/helpers/Auth.ts
+++ b/tests/helpers/Auth.ts
@@ -1,4 +1,4 @@
-import { Page } from "@playwright/test";
+import { Page, APIRequestContext, expect } from "@playwright/test";
 
 export const login = async (page: Page) => {
   let shouldLogin = process.env.TRUSTIFY_AUTH_ENABLED;
@@ -14,5 +14,95 @@ export const login = async (page: Page) => {
     await page.keyboard.press("Enter");
 
     await page.waitForSelector("text=Your Dashboard"); // Ensure login was successful
+  }
+};
+
+export const get_token_endpoint = async (request: APIRequestContext) => {
+  if (process.env.__TOKEN_ENDPOINT) {
+    return process.env.__TOKEN_ENDPOINT;
+  }
+
+  // fetch trustify index page source
+  const indexPage = await request.get(process.env.TRUSTIFY_URL, {
+    maxRedirects: 0,
+  });
+  const indexSource = await indexPage.text();
+  // extract encoded env config
+  const matchIndexJwt = indexSource.match(/window._env="([^"]+)"/);
+  expect(matchIndexJwt, "page has env info about oidc server").toBeTruthy();
+  // decode to json and obtain oidc server url
+  const envInfo = JSON.parse(atob(matchIndexJwt[1]));
+  console.log("env info: " + envInfo); // FIXME: DEBUG
+  expect(envInfo).toHaveProperty("OIDC_SERVER_URL");
+  const oidcURL = envInfo["OIDC_SERVER_URL"];
+
+  console.log("oidc url: " + oidcURL); // FIXME: DEBUG
+
+  // fetch openid config to obtain token endpoint
+  const openidURL = oidcURL + "/.well-known/openid-configuration";
+  const openidConfResp = await request.get(openidURL);
+  expect(openidConfResp).toBeOK();
+  const openidConf = await openidConfResp.json();
+  expect(openidConf).toHaveProperty("token_endpoint");
+
+  process.env.__TOKEN_ENDPOINT = openidConf["token_endpoint"];
+
+  console.log("token endpoint: " + openidConf["token_endpoint"]); // FIXME: DEBUG
+  return openidConf["token_endpoint"];
+};
+
+export const get_token = async (request: APIRequestContext) => {
+  if (process.env.TRUSTIFY_AUTH_ENABLED !== "true") {
+    return;
+  }
+
+  if (process.env.__TOKEN) {
+    // FIXME: verify expiration and refresh if needed
+    return process.env.__TOKEN;
+  }
+
+  const clientId = process.env.TRUSTIFY_AUTH_CLI_ID ?? "cli";
+  const clientSecret = process.env.TRUSTIFY_AUTH_CLI_SECRET;
+
+  let tokenEndpoint = await get_token_endpoint(request);
+
+  const authStr = "Basic " + btoa(clientId + ":" + clientSecret);
+  const tokenResp = await request.post(tokenEndpoint, {
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Authorization: authStr,
+    },
+    form: {
+      grant_type: "client_credentials",
+    },
+  });
+  expect(tokenResp).toBeOK();
+  const tokenJson = await tokenResp.json();
+  expect(tokenJson).toHaveProperty("access_token");
+  expect(tokenJson).toHaveProperty("expires_in");
+
+  const token = tokenJson.access_token;
+  // deduce 1 sec from token expiration (hopefully account for delay or token endpoint response ... yep usage of relative expiration sucks)
+  // multiply by thousand to get milisec from sec
+  // record future Date when it should expire
+  // (we will want auto-refresh)
+  const expires_at = Date.now() + (Number(tokenJson.expires_in) - 1) * 1000;
+
+  process.env.__TOKEN = token;
+  process.env.__TOKEN_EXPIRES_AS = expires_at;
+
+  console.log("got fresh token: " + token); // FIXME: DEBUG
+
+  return token;
+};
+
+export const get_token_header = async (request: APIRequestContext) => {
+  const token = await get_token(request);
+  if (token) {
+    return {
+      Authorization: `Bearer ${token}`,
+    };
+  } else {
+    return {};
   }
 };


### PR DESCRIPTION
Add basic structure and Authentication token helper
for issuing API tests utilizing playwright/ts for them too.

// NOTE - atm work-in-progress:
//  - includes two other PRs too, to be rebased once those are solved
//  - have multiple FIXMEs which we may want cleared before merging