### PR TITLE
Add SKIP_INGESTION variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,13 @@ npm run test
 
 ## Environment Variables
 
-| Variable               | Default Value         | Description                              |
-| ---------------------- | --------------------- | ---------------------------------------- |
-| TRUSTIFY_URL           | http://localhost:8080 | The UI URL                               |
-| TRUSTIFY_AUTH_ENABLED  | false                 | Whether or not auth is enabled in the UI |
-| TRUSTIFY_AUTH_USER     | admin                 | User name to be used when authenticating |
-| TRUSTIFY_AUTH_PASSWORD | admin                 | Password to be used when authenticating  |
+| Variable               | Default Value         | Description                                 |
+| ---------------------- | --------------------- | ------------------------------------------- |
+| TRUSTIFY_URL           | http://localhost:8080 | The UI URL                                  |
+| TRUSTIFY_AUTH_ENABLED  | false                 | Whether or not auth is enabled in the UI    |
+| TRUSTIFY_AUTH_USER     | admin                 | User name to be used when authenticating    |
+| TRUSTIFY_AUTH_PASSWORD | admin                 | Password to be used when authenticating     |
+| SKIP_INGESTION         | false                 | If to skip initial data ingestion / cleanup |
 
 ## Available commands
 

--- a/tests/dependencies/global.setup.ts
+++ b/tests/dependencies/global.setup.ts
@@ -3,6 +3,11 @@ import { expect, Page, test } from "@playwright/test";
 import { login } from "../helpers/Auth";
 
 test.describe("Ingest initial data", () => {
+  test.skip(
+    process.env.SKIP_INGESTION === "true",
+    "Skipping global.setup data ingestion"
+  );
+
   test("SBOMs", async ({ page, baseURL }) => {
     await login(page);
 

--- a/tests/dependencies/global.teardown.ts
+++ b/tests/dependencies/global.teardown.ts
@@ -1,6 +1,13 @@
 import { test as teardown } from "@playwright/test";
 
-teardown("Delete initial data", async ({}) => {
-  console.log("deleting test data...");
-  // Delete the database
+teardown.describe("Delete initial data", () => {
+  teardown.skip(
+    process.env.SKIP_INGESTION === "true",
+    "Skipping global.teardown data cleanup"
+  );
+
+  teardown("SBOMs", async ({}) => {
+    console.log("deleting test data...");
+    // Delete the database
+  });
 });


### PR DESCRIPTION
As initial data ingestion can slow down noticeably startup of tests,
for development it is handy to skip it when rerunning.

When doing so skip also data cleanup, to stay there for reuse
(note that currently teardown/cleanup is not implemented).