### PR TITLE
global.setup: rename test as setup

### DIFF
--- a/tests/api/dependencies/global.setup.ts
+++ b/tests/api/dependencies/global.setup.ts
@@ -5,15 +5,15 @@ import { AxiosInstance } from "axios";
 
 import { ADVISORY_FILES, SBOM_FILES } from "../../common/constants";
 import { UploadSbomResponse } from "../client";
-import { test } from "../fixtures";
+import { test as setup } from "../fixtures";
 
-test.describe("Ingest initial data", () => {
-  test.skip(
+setup.describe("Ingest initial data", () => {
+  setup.skip(
     process.env.SKIP_INGESTION === "true",
     "Skipping global.setup data ingestion"
   );
 
-  test("Upload files", async ({ axios }) => {
+  setup("Upload files", async ({ axios }) => {
     await uploadSboms(axios, SBOM_FILES);
     await uploadAdvisories(axios, ADVISORY_FILES);
   });

--- a/tests/ui/dependencies/global.setup.ts
+++ b/tests/ui/dependencies/global.setup.ts
@@ -1,21 +1,21 @@
 import path from "path";
-import { expect, Page, test } from "@playwright/test";
+import { expect, Page, test as setup } from "@playwright/test";
 import { login } from "../helpers/Auth";
 import { ADVISORY_FILES, SBOM_FILES } from "../../common/constants";
 
-test.describe("Ingest initial data", () => {
-  test.skip(
+setup.describe("Ingest initial data", () => {
+  setup.skip(
     process.env.SKIP_INGESTION === "true",
     "Skipping global.setup data ingestion"
   );
 
-  test("Upload files", async ({ page, baseURL }) => {
+  setup("Upload files", async ({ page, baseURL }) => {
     await login(page);
 
     await page.goto(baseURL!);
     await page.getByRole("link", { name: "Upload" }).click();
 
-    test.setTimeout(120_000);
+    setup.setTimeout(120_000);
     await uploadSboms(page, SBOM_FILES);
     await uploadAdvisories(page, ADVISORY_FILES);
   });


### PR DESCRIPTION
When importing `test` into for global setup, for clarity and consistency,
rename it to `setup` as is recommended in docs/guides[^1].

In case of teardown we have this renaming already there.

[^1]: https://playwright.dev/docs/test-global-setup-teardown#setup