### PR TITLE
Global setup of ignoreHTTPSErrors

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,7 +15,6 @@ const testDir = defineBddConfig({
 
 const DESKTOP_CONFIG = {
   viewport: { height: 961, width: 1920 },
-  ignoreHTTPSErrors: true,
 };
 
 /**
@@ -40,6 +39,8 @@ export default defineConfig({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
+
+    ignoreHTTPSErrors: true,
   },
 
   /* Configure projects for major browsers */
@@ -93,9 +94,6 @@ export default defineConfig({
       name: "api",
       testDir: "./tests/api/features",
       testMatch: /.*\.ts/,
-      use: {
-        baseURL: process.env.TRUSTIFY_URL,
-      },
       dependencies: ["setup-api-data"],
     },
     {
@@ -103,17 +101,11 @@ export default defineConfig({
       testDir: "./tests/api/dependencies",
       testMatch: "*.setup.ts",
       teardown: "cleanup-api-data",
-      use: {
-        ...DESKTOP_CONFIG,
-      },
     },
     {
       name: "cleanup-api-data",
       testDir: "./tests/api/dependencies",
       testMatch: "*.teardown.ts",
-      use: {
-        ...DESKTOP_CONFIG,
-      },
     },
 
     /* Test against mobile viewports. */

--- a/tests/api/fixtures.ts
+++ b/tests/api/fixtures.ts
@@ -129,12 +129,14 @@ type ApiClientFixture = {
 };
 
 export const test = base.extend<ApiClientFixture>({
-  axios: async ({ baseURL, context }, use) => {
+  axios: async ({ baseURL, ignoreHTTPSErrors }, use) => {
     const axiosInstance = axios.create({
       baseURL,
-      httpsAgent: new https.Agent({
-        rejectUnauthorized: false,
-      }),
+      httpsAgent: ignoreHTTPSErrors
+        ? new https.Agent({
+            rejectUnauthorized: false,
+          })
+        : undefined,
     });
 
     if (process.env.TRUSTIFY_AUTH_ENABLED === "true") {
@@ -143,13 +145,15 @@ export const test = base.extend<ApiClientFixture>({
 
     await use(axiosInstance);
   },
-  client: async ({ baseURL }, use) => {
+  client: async ({ baseURL, ignoreHTTPSErrors }, use) => {
     const client = createClient({
       baseURL,
       throwOnError: true,
-      httpsAgent: new https.Agent({
-        rejectUnauthorized: false,
-      }),
+      httpsAgent: ignoreHTTPSErrors
+        ? new https.Agent({
+            rejectUnauthorized: false,
+          })
+        : undefined,
     });
 
     if (process.env.TRUSTIFY_AUTH_ENABLED === "true") {

--- a/tests/api/fixtures.ts
+++ b/tests/api/fixtures.ts
@@ -1,6 +1,7 @@
 import { Client, createClient } from "@hey-api/client-axios";
 import { test as base, expect } from "@playwright/test";
 import axios, { AxiosInstance } from "axios";
+import https from "https";
 
 import { logger } from "../common/constants";
 
@@ -128,8 +129,13 @@ type ApiClientFixture = {
 };
 
 export const test = base.extend<ApiClientFixture>({
-  axios: async ({ baseURL }, use) => {
-    const axiosInstance = axios.create({ baseURL });
+  axios: async ({ baseURL, context }, use) => {
+    const axiosInstance = axios.create({
+      baseURL,
+      httpsAgent: new https.Agent({
+        rejectUnauthorized: false,
+      }),
+    });
 
     if (process.env.TRUSTIFY_AUTH_ENABLED === "true") {
       await initAxiosInstance(axiosInstance, baseURL);
@@ -141,6 +147,9 @@ export const test = base.extend<ApiClientFixture>({
     const client = createClient({
       baseURL,
       throwOnError: true,
+      httpsAgent: new https.Agent({
+        rejectUnauthorized: false,
+      }),
     });
 
     if (process.env.TRUSTIFY_AUTH_ENABLED === "true") {


### PR DESCRIPTION
API Tests PR: 32

- set ignoreHTTPSErrors in the global `use`. E.g.

```js
export default defineConfig({
  use: {
     ignoreHTTPSErrors: true,
  }
```

The idea is to apply it to all project configurations

- The project `api` had `baseURL: process.env.TRUSTIFY_URL,` being defined in its own project but that is redundant as it is defined already in the global `export default defineConfig({})` definition