### PR TITLE
Add Download License Report Test

### DIFF
--- a/tests/ui/features/@sbom-explorer/sbom-explorer.feature
+++ b/tests/ui/features/@sbom-explorer/sbom-explorer.feature
@@ -29,11 +29,12 @@ Feature: SBOM Explorer - View SBOM details
 
     Scenario Outline: Downloading SBOM file
         Given User visits SBOM details Page of "<sbomName>"
-        Then "Download" button is clicked and file corresponds to SBOM "<sbomName>"
+        Then "Download SBOM" action is invoked and downloaded filename is "<expectedSbomFilename>"
+        Then "Download License Report" action is invoked and downloaded filename is "<expectedLicenseFilename>"
 
         Examples:
-            | sbomName    |
-            | quarkus-bom |
+            | sbomName    | expectedSbomFilename | expectedLicenseFilename     |
+            | quarkus-bom | quarkus-bom.json     | quarkus-bom_licenses.tar.gz |
 
     Scenario Outline: View list of SBOM Packages
         Given User visits SBOM details Page of "<sbomName>"

--- a/tests/ui/features/@sbom-explorer/sbom-explorer.step.ts
+++ b/tests/ui/features/@sbom-explorer/sbom-explorer.step.ts
@@ -1,5 +1,6 @@
 import { createBdd } from "playwright-bdd";
 import { expect } from "playwright/test";
+import { DetailsPage } from "../../helpers/DetailsPage";
 import { ToolbarTable } from "../../helpers/ToolbarTable";
 
 export const { Given, When, Then } = createBdd();
@@ -25,14 +26,17 @@ Then("{string} is visible", async ({ page }, fieldName) => {
 });
 
 Then(
-  "{string} button is clicked and file corresponds to SBOM {string}",
-  async ({ page }, buttonName, sbomName) => {
+  "{string} action is invoked and downloaded filename is {string}",
+  async ({ page }, actionName, expectedFilename) => {
     const downloadPromise = page.waitForEvent("download");
-    await page.getByRole("button", { name: buttonName }).click();
+
+    const detailsPage = new DetailsPage(page);
+    detailsPage.clickOnPageAction(actionName);
+
     const download = await downloadPromise;
 
     const filename = download.suggestedFilename();
-    expect(filename).toEqual(`${sbomName}.json`);
+    expect(filename).toEqual(expectedFilename);
   }
 );
 

--- a/tests/ui/helpers/DetailsPage.ts
+++ b/tests/ui/helpers/DetailsPage.ts
@@ -1,5 +1,9 @@
 import { expect, Page } from "@playwright/test";
 
+/**
+ * Describes the Details of an Entity. E.g. SBOM Details Page.
+ * Generally based on https://www.patternfly.org/extensions/component-groups/details-page/
+ */
 export class DetailsPage {
   page: Page;
 
@@ -11,6 +15,11 @@ export class DetailsPage {
     const tab = this.page.locator("button[role='tab']", { hasText: tabName });
     expect(tab).toBeVisible();
     tab.click();
+  }
+
+  async clickOnPageAction(actionName: string) {
+    await this.page.getByRole("button", { name: "Actions" }).click();
+    await this.page.getByRole("menuitem", { name: actionName }).click();
   }
 
   async verifyPageHeader(header: string) {


### PR DESCRIPTION
Depends on:
- backend https://github.com/trustification/trustify/pull/1331
- frontend https://github.com/trustification/trustify-ui/pull/390
 
The UI is adding a Download License Button which changes how the original Download Button was rendered.

This PR adds a test for "Download License Report"

![Screenshot From 2025-03-12 16-32-10](https://github.com/user-attachments/assets/7058c592-8670-4975-a6ad-089b2c9d2258)
