### PR TITLE
api: move out openapi client/sdk examples

### DIFF
--- a/tests/api/features/_openapi_client_examples.ts
+++ b/tests/api/features/_openapi_client_examples.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "../fixtures";
+import { PurlService, SbomService, VulnerabilityService } from "../client";
+import { qBuilder } from "../helpers/params";
+
+test.skip("Examples of OpenAPI based Client/SDK usage", () => {
+  test("Purl by alias - openapi", async ({ client }) => {
+    const serviceResponse = await PurlService.listPurl({
+      client,
+      query: {
+        q: "openssl",
+        offset: 0,
+        limit: 10,
+      },
+    });
+
+    expect(serviceResponse.data?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          purl: "pkg:rpm/redhat/openssl-libs@3.0.7-24.el9?arch=aarch64",
+          base: expect.objectContaining({
+            purl: "pkg:rpm/redhat/openssl-libs",
+          }),
+          version: expect.objectContaining({
+            purl: "pkg:rpm/redhat/openssl-libs@3.0.7-24.el9",
+            version: "3.0.7-24.el9",
+          }),
+          qualifiers: expect.objectContaining({
+            arch: "aarch64",
+          }),
+        }),
+        expect.objectContaining({
+          purl: "pkg:rpm/redhat/openssl-libs@3.0.7-24.el9?arch=x86_64",
+          base: expect.objectContaining({
+            purl: "pkg:rpm/redhat/openssl-libs",
+          }),
+          version: expect.objectContaining({
+            purl: "pkg:rpm/redhat/openssl-libs@3.0.7-24.el9",
+            version: "3.0.7-24.el9",
+          }),
+          qualifiers: expect.objectContaining({
+            arch: "x86_64",
+          }),
+        }),
+      ])
+    );
+  });
+
+  test("List first 10 sboms by name - openapi", async ({ client }) => {
+    const serviceResponse = await SbomService.listSboms({
+      client,
+      query: {
+        offset: 0,
+        limit: 10,
+        sort: "name:asc",
+      },
+    });
+
+    expect(serviceResponse.data).toEqual(
+      expect.objectContaining({
+        total: 6,
+      })
+    );
+  });
+
+  test("Filter Vulnerabilities by severity - openapi", async ({ client }) => {
+    const serviceResponse = await VulnerabilityService.listVulnerabilities({
+      client,
+      query: {
+        offset: 0,
+        limit: 10,
+        sort: "published:asc",
+        q: qBuilder("CVE-2023-2", [
+          {
+            field: "average_severity",
+            operator: "=",
+            value: {
+              list: ["medium", "high"],
+              operator: "OR",
+            },
+          },
+        ]),
+      },
+    });
+
+    expect(serviceResponse.data).toEqual(
+      expect.objectContaining({
+        total: 13,
+      })
+    );
+  });
+});

--- a/tests/api/features/purl.ts
+++ b/tests/api/features/purl.ts
@@ -1,4 +1,3 @@
-import { PurlService } from "../client";
 import { expect, test } from "../fixtures";
 
 test("Purl by alias - vanilla", async ({ axios }) => {
@@ -7,48 +6,6 @@ test("Purl by alias - vanilla", async ({ axios }) => {
   );
 
   expect(vanillaResponse.data.items).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({
-        purl: "pkg:rpm/redhat/openssl-libs@3.0.7-24.el9?arch=aarch64",
-        base: expect.objectContaining({
-          purl: "pkg:rpm/redhat/openssl-libs",
-        }),
-        version: expect.objectContaining({
-          purl: "pkg:rpm/redhat/openssl-libs@3.0.7-24.el9",
-          version: "3.0.7-24.el9",
-        }),
-        qualifiers: expect.objectContaining({
-          arch: "aarch64",
-        }),
-      }),
-      expect.objectContaining({
-        purl: "pkg:rpm/redhat/openssl-libs@3.0.7-24.el9?arch=x86_64",
-        base: expect.objectContaining({
-          purl: "pkg:rpm/redhat/openssl-libs",
-        }),
-        version: expect.objectContaining({
-          purl: "pkg:rpm/redhat/openssl-libs@3.0.7-24.el9",
-          version: "3.0.7-24.el9",
-        }),
-        qualifiers: expect.objectContaining({
-          arch: "x86_64",
-        }),
-      }),
-    ])
-  );
-});
-
-test("Purl by alias - openapi", async ({ client }) => {
-  const serviceResponse = await PurlService.listPurl({
-    client,
-    query: {
-      q: "openssl",
-      offset: 0,
-      limit: 10,
-    },
-  });
-
-  expect(serviceResponse.data?.items).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
         purl: "pkg:rpm/redhat/openssl-libs@3.0.7-24.el9?arch=aarch64",

--- a/tests/api/features/sbom.ts
+++ b/tests/api/features/sbom.ts
@@ -1,29 +1,10 @@
 import { expect, test } from "../fixtures";
 
-import { SbomService } from "../client";
-
 test("List first 10 sboms by name - vanilla", async ({ axios }) => {
   const vanillaResponse = await axios.get(
     "/api/v2/sbom?limit=10&offset=0&sort=name:asc"
   );
   expect(vanillaResponse.data).toEqual(
-    expect.objectContaining({
-      total: 6,
-    })
-  );
-});
-
-test("List first 10 sboms by name - openapi", async ({ client }) => {
-  const serviceResponse = await SbomService.listSboms({
-    client,
-    query: {
-      offset: 0,
-      limit: 10,
-      sort: "name:asc",
-    },
-  });
-
-  expect(serviceResponse.data).toEqual(
     expect.objectContaining({
       total: 6,
     })

--- a/tests/api/features/vulnerability.ts
+++ b/tests/api/features/vulnerability.ts
@@ -1,8 +1,5 @@
 import { expect, test } from "../fixtures";
 
-import { VulnerabilityService } from "../client";
-import { qBuilder } from "../helpers/params";
-
 test("Filter Vulnerabilities by severity - vanilla", async ({ axios }) => {
   // URLSearchParams ensures escaping special characters
   // Without URLSearchParams we would need to do something like:
@@ -15,33 +12,6 @@ test("Filter Vulnerabilities by severity - vanilla", async ({ axios }) => {
 
   const serviceResponse = await axios.get("/api/v2/vulnerability", {
     params: queryParams,
-  });
-
-  expect(serviceResponse.data).toEqual(
-    expect.objectContaining({
-      total: 13,
-    })
-  );
-});
-
-test("Filter Vulnerabilities by severity - openapi", async ({ client }) => {
-  const serviceResponse = await VulnerabilityService.listVulnerabilities({
-    client,
-    query: {
-      offset: 0,
-      limit: 10,
-      sort: "published:asc",
-      q: qBuilder("CVE-2023-2", [
-        {
-          field: "average_severity",
-          operator: "=",
-          value: {
-            list: ["medium", "high"],
-            operator: "OR",
-          },
-        },
-      ]),
-    },
   });
 
   expect(serviceResponse.data).toEqual(


### PR DESCRIPTION
As currently preferred approach for implementing API tests
is the direct url/params over the Client/SDK,
move the hey-api Client/SDK examples to separate file (and skip by default).