### PR TITLE
ui/search: CVEs to Vulnerabilities, tabs, multiple Downloads

### DIFF
--- a/tests/ui/features/search.feature
+++ b/tests/ui/features/search.feature
@@ -35,14 +35,13 @@ Scenario Outline: User toggles the <types> tab and manipulates the list
 	|Vulnerabilities|
 	|Advisories|
 
-
 Scenario Outline: Download Links on the <types> Search Result list
 	When User navigates to Search Results page
 	And Clicks on <types> tab
 	Then <types> list should be listed
 	And Download menu for <type> should be available at the end of the rows
 
-    Examples:
+	Examples:
 	|types|type|
 	|SBOMs|SBOM|
 	|Advisories|Advisory|

--- a/tests/ui/features/search.feature
+++ b/tests/ui/features/search.feature
@@ -71,6 +71,7 @@ Scenario Outline: User searches for a specific <type>
 	And user presses Enter
 	And user switches to the <types> tab
 	Then the <types> list should display the specific <type-name>
+	And columns for <type> results should be visible
 	And the user should be able to filter <types>
 	And user clicks on the "<type>" name
 	And the user should be navigated to the specific "<type>" page

--- a/tests/ui/features/search.feature
+++ b/tests/ui/features/search.feature
@@ -14,13 +14,13 @@ Scenario: User visits search page without filling anything
 	And user presses Enter
 	Then a total number of "SBOMs" should be visible in the tab
 	And a total number of "Packages" should be visible in the tab
-	And a total number of "CVEs" should be visible in the tab
+	And a total number of "Vulnerabilities" should be visible in the tab
 	And a total number of "Advisories" should be visible in the tab
 
-Scenario Outline: User toggles the <types> list and manipulates the list
-	When User navigates to Search results page 
-	And user toggles the <types> list
-	Then the <types> list should have specific filter set
+Scenario Outline: User toggles the <types> tab and manipulates the list
+	When User navigates to Search results page
+	And user switches to the <types> tab
+	Then the results should show list of <types>
 	And the user should be able to filter <types>
 	And the <types> list should be sortable
 	And the <types> list should be limited to 10 items
@@ -28,27 +28,28 @@ Scenario Outline: User toggles the <types> list and manipulates the list
 	And the user should be able to increase pagination for the <types>
 	And First column on the search results should have the link to <types> explorer pages
 
-Scenario Outline: Download Links on the <types> Search Result list
-	When User navigates to Search Results page
-	And Clicks on <types> tab
-	Then <types> list should be listed
-	And Download link should be available at the end of the rows
-	
-        Examples:
-	|types|
-	|SBOMs|
-	|Advisories|
-
 	Examples:
 	|types|
 	|SBOMs|
 	|Packages|
-	|CVEs|
+	|Vulnerabilities|
 	|Advisories|
 
-Scenario Outline: Autofill shows results matched on <input> 
-	When user starts typing a <input> in the search bar  
-	Then the autofill dropdown should display items matching the <input> 
+
+Scenario Outline: Download Links on the <types> Search Result list
+	When User navigates to Search Results page
+	And Clicks on <types> tab
+	Then <types> list should be listed
+	And Download menu for <type> should be available at the end of the rows
+
+    Examples:
+	|types|type|
+	|SBOMs|SBOM|
+	|Advisories|Advisory|
+
+Scenario Outline: Autofill shows results matched on <input>
+	When user starts typing a <input> in the search bar
+	Then the autofill dropdown should display items matching the <input>
 	And the results should be limited to 5 suggestions
 
 	Examples:
@@ -58,26 +59,26 @@ Scenario Outline: Autofill shows results matched on <input>
 	|CVE description|
 
 Scenario: Autofill should not match any packages
-	When user starts typing a "package name" in the search bar  
+	When user starts typing a "package name" in the search bar
 	Then the autofill dropdown should not display any packages
 	And the results should be limited to 5 suggestions
 
-Scenario: Search bar should not preview anything when no matches are found 
+Scenario: Search bar should not preview anything when no matches are found
 	When user starts typing a "non-existent name" in the search bar
 	Then The autofill drop down should not show any values
 
-Scenario Outline: User searches for a specific <type> 
+Scenario Outline: User searches for a specific <type>
 	When user types a <type-name> in the search bar
 	And user presses Enter
-	And user toggles the <types> list
-	Then the <types> list should display the specific <type-name> 
-	And the user should be able to filter <types> 
+	And user switches to the <types> tab
+	Then the <types> list should display the specific <type-name>
+	And the user should be able to filter <types>
 	And user clicks on the "<type>" name
-	And the user should be navigated to the specific "<type>" page 
+	And the user should be navigated to the specific "<type>" page
 
 	Examples:
 	|type|types|type-name|
 	|SBOM|SBOMs|SBOM name|
-	|CVE|CVEs|CVE ID|
+	|vulnerability|Vulnerabilities|CVE ID|
 	|package|Packages|package name|
 	|advisory|Advisories|advisory name|


### PR DESCRIPTION
Update Search scenario to match implementation in trustify v2.

Main point is the CVEs are labeled Vulnerabilities instead.

Also there is currently:
- not a single list of results but still tabs by type
- download links is instead menu with one or more links inside

There was mistake with mixed up 'Example' blocks
between/after scenarios outlines:
- User toggles the <types> list and manipulates the list
- Download Links on the <types> Search Result list so while updating them moved the example block to correct place.

Related to: TC-2191