### PR TITLE
api: fix space breaking oidc endpoint detection

### DIFF
--- a/tests/api/fixtures.ts
+++ b/tests/api/fixtures.ts
@@ -66,7 +66,7 @@ export const discoverTokenEndpoint = async (
     }),
   });
 
-  const matcher = indexPage.data.match(/window._env="([^"]+)"/);
+  const matcher = indexPage.data.match(/window._env\s*=\s*"([^"]+)"/);
   const serverConfig = matcher?.[1];
   if (!serverConfig) {
     return null;


### PR DESCRIPTION
Allow extra spaces around assignment character
in pattern used for detection of oidc url.