### PR TITLE
task: align upload tests to new upload pages

### DIFF
--- a/tests/ui/dependencies/global.setup.ts
+++ b/tests/ui/dependencies/global.setup.ts
@@ -36,7 +36,7 @@ const uploadSboms = async (page: Page, files: string[]) => {
   );
 
   await expect(
-    page.locator("#upload-sbom-tab-content .pf-v6-c-expandable-section__toggle")
+    page.locator(".pf-v6-c-expandable-section__toggle")
   ).toContainText(`${files.length} of ${files.length} files uploaded`, {
     timeout: SETUP_TIMEOUT / 2,
   });
@@ -54,9 +54,7 @@ const uploadAdvisories = async (page: Page, files: string[]) => {
   );
 
   await expect(
-    page.locator(
-      "#upload-advisory-tab-content .pf-v6-c-expandable-section__toggle"
-    )
+    page.locator(".pf-v6-c-expandable-section__toggle")
   ).toContainText(`${files.length} of ${files.length} files uploaded`, {
     timeout: SETUP_TIMEOUT / 2,
   });


### PR DESCRIPTION
The UI will change the place where the Upload button is located.
Before:
- The was an Upload menu on the left sidebar. The page contains both SBOM and Advisory Uploads separated by Tabs

After:
- The SBOM List page has a "Upload SBOM" button
- The Advisory List page has a "Upload Advisory" button

