### PR TITLE
task: replace trustify-operatory by trustify-ui compose files

### DIFF
--- a/.github/workflows/global-ci.yaml
+++ b/.github/workflows/global-ci.yaml
@@ -14,9 +14,8 @@ on:
 
 jobs:
   e2e:
-    uses: trustification/trustify-ci/.github/workflows/global-ci.yml@main
+    uses: trustification/trustify-ui/.github/workflows/ci-global-template.yaml@main
     with:
-      operator_bundle: "ghcr.io/trustification/trustify-operator-bundle:latest"
       run_api_tests: true
       run_ui_tests: true
       tests_ref: ${{ github.event.number && format('refs/pull/{0}/merge', github.event.number) || '' }}


### PR DESCRIPTION
The repository https://github.com/trustification/trustify-operator/ is going to be deprecated in favor of https://github.com/trustification/trusted-profile-analyzer-operator

There was also the desire of getting rid of the repository trustify-ci to reduce the number of repositories that will be donated to the GUAC community. Therefore, this PR makes us stop relying on trustify-ci but only on the reusable actions from trustify-ui.

What do you think? is it a good idea?